### PR TITLE
Future Redeemed voices in base game and vice versa

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(xenomods
 		xenomods/menu/Section.cpp
 		xenomods/menu/Option.cpp
 
+		xenomods/modules/AudioUtils.cpp
 		xenomods/modules/DebugStuff.cpp
 		xenomods/modules/CameraTools.cpp
 		xenomods/modules/RenderingControls.cpp

--- a/src/xenomods/modules/AudioUtils.cpp
+++ b/src/xenomods/modules/AudioUtils.cpp
@@ -1,0 +1,75 @@
+#include "AudioUtils.hpp"
+#include "DebugStuff.hpp"
+
+namespace {
+
+	// #define LOAD_WWISE_VO_BASE_GAME_ADDR 0x7100bfc0a4
+	// // struct LoadWWiseVOBaseGame : skylaunch::hook::Trampoline<LoadWWiseVOBaseGame> {
+  // //   static void Hook(void* wwise, unsigned long dlc1, unsigned long dlc2, unsigned long dlc3, unsigned long langFlags) {
+  // //     xenomods::g_Logger->LogDebug("Calling LoadWWiseVOBaseGame");
+  // //     Orig(wwise, dlc1, dlc2, dlc3, langFlags);
+
+  // //     xenomods::g_Logger->LogDebug("Force loading DLC4");
+  // //     auto LoadWWiseVODLC4 = reinterpret_cast<void(*)(void*, unsigned long)>(0xbfbe04);  
+  // //     LoadWWiseVODLC4(wwise, langFlags);
+  // //   }
+	// // };
+
+	const uintptr_t LoadWWiseBnkAddr = 0x7100061430;
+	struct LoadWWiseBnk : skylaunch::hook::Trampoline<LoadWWiseBnk> {
+    static void Hook(unsigned long wwise, unsigned long flags, const char* bnkName, unsigned long unk2, unsigned long unk3, unsigned long unk4) {
+			xenomods::g_Logger->LogDebug("Loading WWise Bank: {}", bnkName);
+			Orig(wwise, flags, bnkName, unk2, unk3, unk4);
+			
+			if (strcmp(bnkName, "vo_035.bnk") == 0) { // rex hero
+        xenomods::g_Logger->LogDebug("Rex Hero detected, loading DLC4 party VO");
+				for (int i = 0x24; i <= 0x2B; i++) {
+					xenomods::g_Logger->LogDebug("vo_{:03d}.bnk Force Loading VO", i);
+					Orig(wwise, flags, fmt::format("vo_{:03d}.bnk", i).c_str(), unk2, unk3, unk4);
+				}
+        xenomods::g_Logger->LogDebug("DLC4 party loaded");
+				return;
+	    }
+
+			if (strcmp(bnkName, "vo_043.bnk") == 0) { // na'el alpha
+				xenomods::g_Logger->LogDebug("Na'el / Alpha detected, loading base game party + heroes VO");
+				for (int i = 0x1; i <= 0x23; i++) {
+					if (
+						i == 0x0E || // Joran
+						i == 0x1C || // Nimue
+						i == 0x20 || // Ino (TODO: need to load DLC2 voice pck)
+						i == 0x21    // Masha (TODO: need to load DLC3 voice pck)
+					) {
+						continue;
+					}
+
+					xenomods::g_Logger->LogDebug("vo_{:03d}.bnk Force Loading VO", i);
+					Orig(wwise, flags, fmt::format("vo_{:03d}.bnk", i).c_str(), unk2, unk3, unk4);
+				}
+				xenomods::g_Logger->LogDebug("Base game party + heroes loaded");
+				return;
+			}
+		}
+	};
+}
+
+namespace xenomods {
+	void AudioUtils::Initialize() {
+		UpdatableModule::Initialize();
+		g_Logger->LogDebug("Setting up audio utils...");
+    
+    // LoadWWiseVOBaseGame::HookFromBase(LOAD_WWISE_VO_BASE_GAME_ADDR);
+		LoadWWiseBnk::HookFromBase(LoadWWiseBnkAddr);
+
+
+		auto modules = g_Menu->FindSection("modules");
+		if (modules != nullptr) {
+			auto section = modules->RegisterSection(STRINGIFY(AudioUtils), "Audio Utils");
+
+			// auto toggles = section->RegisterSection(toggleKey, "Toggles...");
+			// toggles->RegisterOption<bool>(skipUIRendering, "Skip UI rendering");
+		}
+	}
+
+	XENOMODS_REGISTER_MODULE(AudioUtils);
+} // namespace xenomods

--- a/src/xenomods/modules/AudioUtils.hpp
+++ b/src/xenomods/modules/AudioUtils.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "UpdatableModule.hpp"
+
+namespace xenomods {
+
+	struct AudioUtils : public xenomods::UpdatableModule {
+		void Initialize() override;
+		bool NeedsUpdate() const override {
+			return false;
+		}
+	};
+
+} // namespace xenomods


### PR DESCRIPTION
if you bring party members from Future Redeemed into the base game and vice versa, their characters are unvoiced. this is because the each game selectively picks which VO character banks to load (in code).
* for base game, this is base game party + heroes + Ino (DLC 2) + Masha (DLC 3) + hero Shulk/Rex (DLC 4).
* for Future Redeemed, this is only the Future Redeemed party + Na'el   (all DLC 4).

this module hooks into the bank loading function and detects if Hero Rex is being loaded, assumes this means that Base Game VO banks were loaded and that should trigger loading the Future Redeemed ones.

same when Na'el / Alpha (from Future Redeemed) is loaded, this triggers loading all the base game party + heroes.

- [x] 2.0.0 support
- [ ] 2.1.0 support
- [ ] 2.1.1 support
- [ ] lock hook to bf3 only
- [ ] enabling VO override should be a config toml thing
- [ ] support Ino & Masha (need to force load DLC2 and DLC3 VO packs if they aren't already loaded)
